### PR TITLE
Ensures that the external content headers files contains the Content-…

### DIFF
--- a/src/main/java/org/fcrepo/upgrade/utils/HttpConstants.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/HttpConstants.java
@@ -29,4 +29,5 @@ public class HttpConstants {
 
     public static final String CONTENT_TYPE_HEADER = "Content-Type";
     public static final String LOCATION_HEADER = "Location";
+    public static final String CONTENT_LOCATION_HEADER = "Content-Location";
 }

--- a/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
+++ b/src/main/java/org/fcrepo/upgrade/utils/RdfConstants.java
@@ -22,6 +22,8 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -34,6 +36,7 @@ import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
  * @author dbernstein
  */
 public class RdfConstants {
+
     private RdfConstants() {
     }
 
@@ -43,8 +46,14 @@ public class RdfConstants {
     public static final String PREMIS_NS = "http://www.loc.gov/premis/rdf/v1#";
     public static final String EBUCORE_NS = "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#";
 
-    public static final Resource LDP_NON_RDFSOURCE =
-        ResourceFactory.createResource("http://www.w3.org/ns/ldp#NonRDFSource");
+    public static final Resource LDP_NON_RDFSOURCE = ResourceFactory.createResource(LDP_NS + "NonRDFSource");
+    public static final Resource LDP_CONTAINER = ResourceFactory.createResource(LDP_NS + "Container");
+    public static final Resource LDP_DIRECT_CONTAINER = ResourceFactory.createResource(LDP_NS + "DirectContainer");
+    public static final Resource LDP_INDIRECT_CONTAINER = ResourceFactory.createResource(LDP_NS + "IndirectContainer");
+    public static final Resource LDP_BASIC_CONTAINER = ResourceFactory.createResource(LDP_NS + "BasicContainer");
+    public static final List<Resource> LDP_CONTAINER_TYPES = Arrays.asList(LDP_BASIC_CONTAINER,
+                                                                           LDP_DIRECT_CONTAINER,
+                                                                           LDP_INDIRECT_CONTAINER);
     public static final Property EBUCORE_HAS_MIME_TYPE =
         createProperty(EBUCORE_NS + "hasMimeType");
     public static final Property HAS_ORIGINAL_NAME =


### PR DESCRIPTION
…Location field on 4->5 upgrade so that it matches  F5 exports.
Also ensures that the  rdf type BasicContainer  triple is  present  in generic Container  RDF.

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3432

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This pull request essentially ensures that the output of a F4->F5 upgrade mirrors the output of a F5 export closely enough that is possible to run a F4->F5 upgrade and immediately run a F5->F6 upgrade using the output of the former as the input to the latter without any failures.

# What's new?
This PR adds a BasicContainer triple to the RDF of an rdf container that lacks a concrete container triple.  In addition it ensures that the expected Content-Location header is present in the external.headers file as is required for indicating a "redirect" in the semantics of F5. 

# How should this be tested?
```
mkdir -p /tmp/fcrepo-6.0.0-ocfl

# upgrade the test F4 repo to F5
java -Dfcrepo.log=DEBUG -jar target/fcrepo-upgrade-utils-6.0.0-SNAPSHOT.jar -i src/test/resources/4.7.5-export -s 4.7.5 -t 5+ -o /tmp/f4-f5-upgrade
# upgrade the resulting F5 repository to F6
java -Dfcrepo.log=DEBUG -jar target/fcrepo-upgrade-utils-6.0.0-SNAPSHOT.jar -i /tmp/f4-f5-upgrade -o /tmp/fcrepo-6.0.0-ocfl/data -s 5+ -t 6+ -u http://localhost:8080/rest
# startup fedora using the newly created ocfl directory
mvn -Dfcrepo.home=/tmp/fcrepo-6.0.0-ocfl jetty:run -pl fcrepo-webapp

```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
